### PR TITLE
Set Solr container hostnames due to conflict with DNS

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3'
-
 services:
   web:
     build: web
@@ -11,8 +9,9 @@ services:
       - solr
 
   solr1:
-    image: solr:9.2.1
+    image: solr:9.6.1
     container_name: solr1
+    hostname: solr1.internal
     restart: always
     ports:
      - "8981:8983"
@@ -26,8 +25,9 @@ services:
       - zoo3
 
   solr2:
-    image: solr:9.2.1
+    image: solr:9.6.1
     container_name: solr2
+    hostname: solr2.internal
     restart: always
     ports:
      - "8982:8983"
@@ -41,8 +41,9 @@ services:
       - zoo3
 
   solr3:
-    image: solr:9.2.1
+    image: solr:9.6.1
     container_name: solr3
+    hostname: solr3.internal
     restart: always
     ports:
      - "8983:8983"
@@ -56,8 +57,9 @@ services:
       - zoo3
 
   solr4:
-    image: solr:9.2.1
+    image: solr:9.6.1
     container_name: solr4
+    hostname: solr4.internal
     restart: always
     ports:
      - "8984:8983"

--- a/web/setup.sh
+++ b/web/setup.sh
@@ -4,7 +4,7 @@ if [ ! -f .initialized ]; then
 
    apk update; apk add curl
 
-   solrHOST="solr1"
+   solrHOST="solr1.internal"
    solrPORT="8983"
    solrSHARDS="4"
    solrREPLIC="1"


### PR DESCRIPTION
A user reported issues when configuring Rapture that prevented it's automatic creation/configuration through the `setup.sh` script. Upon further inspection, this issue was DNS conflicts that presented themselves when the host DNS server was non-default, such as a self-hosted instance of Pi-Hole.

In this commit, the `docker-compose.yml` and `setup.sh` files are modified to address this issue. In the Docker Compose file, hostnames were added to each Solr container. The `setup.sh` variables were updated accordingly.